### PR TITLE
Add rule: track plans as sub-issues with specs in .github/plans/

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -32,7 +32,7 @@ Repo: https://github.com/mohansharma-me/loom
 - Plan content goes in `.github/plans/<issue-number>-<design|implementation>.md` in the repo.
 - The sub-issue body contains a summary and links to the full spec file.
 - Plan file updates are committed alongside the implementation work.
-- **Do NOT read files in `.github/plans/` during codebase exploration.** Only read a plan file when explicitly working on the corresponding issue.
+- **Do NOT read `.github/plans/` during general codebase exploration.** Only read a plan file when the current task is scoped to its parent issue. When working on an issue, reading and updating its plan files is expected.
 
 ## Key Files
 


### PR DESCRIPTION
## Summary

- Adds **Rule 4 (Post Plans as Sub-Issues)** to CLAUDE.md requiring design and implementation plans to be tracked as sub-issues on the target GitHub issue.
- Plan specs are stored in `.github/plans/<issue-number>-<design|implementation>.md` to avoid character limits and provide better UX.
- Sub-issue body contains a summary + link to the full spec file.
- Adds exclusion rule: agents must not read `.github/plans/` during codebase exploration.
- Updates Workflow section to include plan creation as step 2.

## Test plan

- [ ] Verify CLAUDE.md renders correctly on GitHub
- [ ] Confirm workflow steps are numbered correctly
- [ ] Validate rule is picked up in new Claude Code sessions

🤖 Generated with [Claude Code](https://claude.com/claude-code)